### PR TITLE
Update to workaround race condition in token store

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>1.8</java.version>
+        <!-- spring-security-oauth.version>2.0.14.BUILD-SNAPSHOT</spring-security-oauth.version-->
     </properties>
 
     <dependencies>

--- a/src/main/java/com/github/bilak/OauthCaller.java
+++ b/src/main/java/com/github/bilak/OauthCaller.java
@@ -1,6 +1,16 @@
 package com.github.bilak;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
 import org.bouncycastle.util.encoders.Base64;
+
 import org.springframework.http.HttpMethod;
 import org.springframework.http.RequestEntity;
 import org.springframework.http.ResponseEntity;
@@ -10,17 +20,6 @@ import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.client.RestOperations;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
-
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
-import java.util.Arrays;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadLocalRandom;
-import java.util.concurrent.TimeUnit;
 
 /**
  * @author lvasek.
@@ -33,7 +32,8 @@ public class OauthCaller {
 			for (int i = 0; i < 20; i++) {
 				executorService.execute(() -> new OauthCaller().callAuth());
 			}
-		} finally {
+		}
+		finally {
 			executorService.shutdown();
 		}
 	}
@@ -44,7 +44,8 @@ public class OauthCaller {
 
 		Map<String, List<String>> headers = new LinkedHashMap<>();
 		headers.put("Content-Type", Arrays.asList("application/x-www-form-urlencoded"));
-		headers.put("authorization", Arrays.asList("Basic " + new String(Base64.encode("demo:demo".getBytes()))));
+		headers.put("authorization", Arrays
+				.asList("Basic " + new String(Base64.encode("demo:demo".getBytes()))));
 
 		UriComponentsBuilder builder = null;
 		try {
@@ -53,19 +54,21 @@ public class OauthCaller {
 					.queryParam("username", URLEncoder.encode("jdoe@domain.com", "UTF-8"))
 					.queryParam("password", "password")
 					.queryParam("grant_type", "password");
-		} catch (UnsupportedEncodingException e) {
-			e.printStackTrace();
+		}
+		catch (UnsupportedEncodingException e) {
+			throw new IllegalStateException("Cannot build URL");
 		}
 
 		try {
-			return restOperations.exchange(new RequestEntity<>(new LinkedMultiValueMap<>(headers), HttpMethod.POST, builder.build(true).toUri()),
+			return restOperations.exchange(
+					new RequestEntity<>(new LinkedMultiValueMap<>(headers),
+							HttpMethod.POST, builder.build(true).toUri()),
 					OAuth2AccessToken.class);
-		} catch (HttpStatusCodeException e) {
-			e.printStackTrace();
-			System.out.println("ERROR RESPONSE " + e.getResponseBodyAsString());
 		}
-
-		return null;
+		catch (HttpStatusCodeException e) {
+			System.out.println("ERROR RESPONSE " + e.getResponseBodyAsString());
+			throw e;
+		}
 
 	}
 }

--- a/src/main/java/com/github/bilak/configuration/CustomTokenServices.java
+++ b/src/main/java/com/github/bilak/configuration/CustomTokenServices.java
@@ -2,41 +2,55 @@ package com.github.bilak.configuration;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import org.springframework.dao.DuplicateKeyException;
+import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Recover;
 import org.springframework.retry.annotation.Retryable;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.oauth2.common.OAuth2AccessToken;
 import org.springframework.security.oauth2.provider.OAuth2Authentication;
 import org.springframework.security.oauth2.provider.token.DefaultTokenServices;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * @author lvasek.
  */
 public class CustomTokenServices extends DefaultTokenServices {
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(CustomTokenServices.class);
+	private static final Logger LOGGER = LoggerFactory
+			.getLogger(CustomTokenServices.class);
 
 	@Override
-	@Retryable(include = DuplicateKeyException.class)
-	public OAuth2AccessToken createAccessToken(OAuth2Authentication authentication) throws AuthenticationException {
+	@Retryable(exclude = AuthenticationException.class, backoff = @Backoff(multiplier = 1.1, delay = 200))
+	public OAuth2AccessToken createAccessToken(OAuth2Authentication authentication)
+			throws AuthenticationException {
 		try {
 			return super.createAccessToken(authentication);
-		} catch (DuplicateKeyException ex) {
-			LOGGER.info(String.format("DuplicateKeyException while creating access token %s", ex));
+		}
+		catch (DuplicateKeyException ex) {
+			LOGGER.info(String
+					.format("DuplicateKeyException while creating access token %s", ex));
 			throw ex;
-		} catch (Exception ex) {
-			LOGGER.info(String.format("Exception while creating access token %s", ex));
+		}
+		catch (Exception ex) {
+			LOGGER.error("Exception while creating access token", ex);
 			throw new RuntimeException(ex);
 		}
 	}
 
 	@Recover
+	@Transactional
 	public OAuth2AccessToken recoverAccessToken(OAuth2Authentication authentication)
 			throws AuthenticationException {
 		try {
-			return getAccessToken(authentication);
-		} catch (Exception ex) {
+
+			OAuth2AccessToken accessToken = getAccessToken(authentication);
+			if (accessToken != null) {
+				return accessToken;
+			}
+		}
+		catch (Exception ex) {
 			LOGGER.error("Unable to recover from createAccessToken error", ex);
 		}
 		throw new IllegalStateException("Cannot create access token");

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,7 +11,6 @@ spring:
       write-dates-as-timestamps: false
   datasource:
     url: ${AUTH_SERVICE_DB_URL:jdbc:h2:~/h2db/spring-oauth2-access-token-issue;AUTO_SERVER=TRUE;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE}
-    driver-class-name: org.h2.Driver
     username: sa
     password: sa
   jpa:
@@ -22,6 +21,7 @@ spring:
 
 logging:
   level.org.springframework.security.oauth2: DEBUG
+  level.org.springframework.retry: DEBUG
 
 
 security:
@@ -45,7 +45,7 @@ liquibase:
 spring:
   profiles: jpapostgre-dev
   datasource:
-    url: jdbc:postgresql://localhost:5432/spring-oauth2-access-token-issue
+    # url: jdbc:postgresql://localhost:5432/spring-oauth2-access-token-issue
     driver-class-name: org.postgresql.Driver
     username: pguser
     password: pguser

--- a/src/test/java/com/github/bilak/SpringOauth2AccessTokenIssueApplicationTests.java
+++ b/src/test/java/com/github/bilak/SpringOauth2AccessTokenIssueApplicationTests.java
@@ -1,21 +1,29 @@
 package com.github.bilak;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.oauth2.common.OAuth2AccessToken;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import java.util.concurrent.*;
-
 import static org.junit.Assert.assertEquals;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest(classes = { SpringOauth2AccessTokenIssueApplication.class }, webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
+@SpringBootTest(classes = {
+		SpringOauth2AccessTokenIssueApplication.class }, webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 public class SpringOauth2AccessTokenIssueApplicationTests {
 
 	ExecutorService executorService;
@@ -32,19 +40,21 @@ public class SpringOauth2AccessTokenIssueApplicationTests {
 
 	@Test
 	public void testAuthPerformance() {
-		int numberOfCalls = 50;
-		CompletableFuture<ResponseEntity<OAuth2AccessToken>>[] tasksArray = new CompletableFuture[numberOfCalls];
+		int numberOfCalls = 400;
+		List<CompletableFuture<ResponseEntity<OAuth2AccessToken>>> tasksArray = new ArrayList<>(
+				numberOfCalls);
 
 		for (int i = 0; i < numberOfCalls; i++) {
-			tasksArray[i] = CompletableFuture
-					.supplyAsync(() -> {
-						try {
-							TimeUnit.MILLISECONDS.sleep(ThreadLocalRandom.current().nextInt(200));
-						} catch (InterruptedException e) {
-							e.printStackTrace();
-						}
-						return new OauthCaller().callAuth();
-					}, executorService);
+			tasksArray.add(CompletableFuture.supplyAsync(() -> {
+				try {
+					TimeUnit.MILLISECONDS.sleep(ThreadLocalRandom.current().nextInt(200));
+				}
+				catch (InterruptedException e) {
+					Thread.currentThread().interrupt();
+					throw new IllegalStateException("Interrupted");
+				}
+				return new OauthCaller().callAuth();
+			}, executorService));
 		}
 
 		for (CompletableFuture<ResponseEntity<OAuth2AccessToken>> task : tasksArray) {
@@ -54,5 +64,3 @@ public class SpringOauth2AccessTokenIssueApplicationTests {
 	}
 
 }
-
-


### PR DESCRIPTION
Three changes:

1. Tidy up the test case and make it fail a bit more cleanly
2. Add a custom key generator to the token store to work around
a race condition
3. Add backoff to the retry configuration in the token store

The test is green (generates 400 tokens with no errors).